### PR TITLE
Update network

### DIFF
--- a/ananse/commands/network.py
+++ b/ananse/commands/network.py
@@ -6,8 +6,7 @@
 # distribution.
 
 from __future__ import print_function
-import sys
-import os
+
 
 import ananse.network
 
@@ -19,13 +18,16 @@ def network(args):
 
     b = ananse.network.Network(
         ncore=args.ncore,
-        genome=args.genome, 
-        gene_bed=args.annotation, 
+        genome=args.genome,
+        gene_bed=args.annotation,
         include_promoter=args.include_promoter,
         include_enhancer=args.include_enhancer
         # pfmfile=args.pfmfile,
         # promoter=args.promoter
     )
     b.run_network(
-        args.binding, args.fin_expression, args.corrfiles, args.outfile
+        binding=args.binding,
+        fin_expression=args.fin_expression,
+        corrfiles=args.corrfiles,
+        outfile=args.outfile,
     )

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -384,7 +384,7 @@ class Network(object):
             binding_fname,
             sep="\t",
             usecols=["factor", "enhancer", "binding"],
-        )[["factor", "enhancer", "binding"]]
+        )
         if tfs is not None:
             ddf = ddf[ddf["factor"].isin(tfs)]
 
@@ -474,9 +474,6 @@ class Network(object):
         tfs.rename(
             columns={"target": "tf", "target_expression": "tf_expression"}, inplace=True
         )
-
-        expression["key"] = 0
-        tfs["key"] = 0
 
         # Merge TF and target gene expression information
         network = expression.merge(tfs, how="outer")

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -474,6 +474,9 @@ class Network(object):
         tfs.rename(
             columns={"target": "tf", "target_expression": "tf_expression"}, inplace=True
         )
+        
+        expression["key"] = 0
+        tfs["key"] = 0
 
         # Merge TF and target gene expression information
         network = expression.merge(tfs, how="outer")

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,6 @@ setup(
         "networkx",
         "tables",
         "genomepy >= 0.8.3",
+        "pyranges",
     ],
 )


### PR DESCRIPTION
This is an initial refactor of the network step. For now, major changes are to remove unnecessary code and to simplify. This can than serve as a base for adding new functionality. API is still compatible with current version, and the logic is also more or less the same.

Changes:
* Option to specify a list of TFs to use.

Bugfixes:
* Peaks that overlap promoter now get weight 1 instead of 0.
* Fixed issue with some annotation BED files that resulted in missing genes in the network.