### PR TITLE
Update enhancer_binding.py

### DIFF
--- a/ananse/enhancer_binding.py
+++ b/ananse/enhancer_binding.py
@@ -270,7 +270,7 @@ class ScorePeaks:
         fit the peak scores to a distribution
         """
         bed = pd.read_csv(bam_coverage, header=None, sep="\t")
-        region = bed[0] + ":" + bed[1].astype(str) + "-" + bed[2].astype(str)
+        region = bed[0].astype(str) + ":" + bed[1].astype(str) + "-" + bed[2].astype(str)
         score = bed[3]
 
         # obtain a distribution


### PR DESCRIPTION
add .astype(str) to chrom ID in case of mapping to GRCH38 (which combines 1's and patch1, so some of them will be recognized as str, other as int.
int + str causes an crash.