### PR TITLE
correct minimum gimme version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "setuptools >= 0.7",
         "adjusttext",
         "dask",
-        "gimmemotifs >=0.14.4",
+        "gimmemotifs >=0.15.1",
         "loguru",
         "networkx",
         "openpyxl",


### PR DESCRIPTION
The gimmemotifs function `scan_regionfile_to_table` was introduced in gimmemotifs `0.15.1` if I understand correctly. 