### PR TITLE
Genes

### DIFF
--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -110,8 +110,8 @@ def read_expression(fname):
         },
     )[["log2FoldChange", "padj"]]
     # removes NaNs
-    # average values for duplicate gene names (none hopefully)
     df.dropna(inplace=True)
+    # average values for duplicate gene names (none hopefully)
     df = df.groupby(by=df.index, dropna=True).mean(0)
 
     # absolute fold change

--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -87,9 +87,11 @@ def read_expression(fname):
     Parameters
     ----------
     fname: str
-        a tab-separated file containing (at least) 3 columns
-        (HGNC gene symbols, (adjusted) p-values and log2foldchange)
-        header is omitted if starting with "resid"
+        DESeq2 output file. 
+        Tab-separated, containing (at least) 3 columns:
+        1. a column with names/IDs (column name is ignored), 
+        2. named column "padj" (adjusted p-values)
+        3. named column "log2FoldChange"
 
     Returns
     -------

--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -79,12 +79,22 @@ def difference(S, R):
 
 
 def read_expression(fname):
-    """Read differential gene expression analysis output, return dictionary with namedtuples of scores, absolute fold
+    """
+    Read differential gene expression analysis output,
+    return dictionary with namedtuples of scores, absolute fold
     change and "real" (directional) fold change.
 
-    input:
-    a tab-separated file containing 3 columns (HGNC gene symbols, (adjusted) p-values and log2foldchange)
-    header is omitted if starting with "resid"
+    Parameters
+    ----------
+    fname: str
+        a tab-separated file containing (at least) 3 columns
+        (HGNC gene symbols, (adjusted) p-values and log2foldchange)
+        header is omitted if starting with "resid"
+
+    Returns
+    -------
+    dict
+        namedtuples of scores, absolute fold change and "real" (directional) fold change.
     """
     expression_change = dict()
 
@@ -92,17 +102,26 @@ def read_expression(fname):
         fname,
         index_col=0,
         header=0,
-        dtype={"resid": str, "log2FoldChange": float, "padj": float},
-    )
+        dtype={
+            "resid": str,
+            "Unnamed: 0": str,
+            "log2FoldChange": float,
+            "padj": float,
+        },
+    )[["log2FoldChange", "padj"]]
+    # removes NaNs
+    # average values for duplicate gene names (none hopefully)
+    df.dropna(inplace=True)
+    df = df.groupby(by=df.index, dropna=True).mean(0)
 
     # absolute fold change
     df["fc"] = df["log2FoldChange"].abs()
 
-    # get the gscore (absolute fold change if significanlty differential)
+    # get the gscore (absolute fold change if significantly differential)
     df["score"] = df["fc"] * (df["padj"] < 0.05)
 
     for k, row in df.iterrows():
-        expression_change[row.name] = Expression(
+        expression_change[k] = Expression(
             score=row.score, absfc=row.fc, realfc=row.log2FoldChange
         )
 

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -261,6 +261,8 @@ class Network(object):
             DataFrame with enhancer regions, gene names, distance and weight.
         """
         genes = region_gene_overlap(peak_pr, self.gene_bed)
+        if genes.empty:
+            return pd.Dataframe()
 
         # Get the distance from center of enhancer to TSS
         # Correct for extension
@@ -414,7 +416,10 @@ class Network(object):
                 promoter=promoter,
                 full_weight_region=full_weight_region,
             )
-            gene_df = gene_df.dropna()
+            gene_df.dropna(inplace=True)
+            if gene_df.empty:
+                logger.debug(f"No genes found on {chrom}")
+                continue
 
             bp = pd.DataFrame(index=enhancers[idx].index)
 

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -518,6 +518,7 @@ class Network(object):
             # combine expression values for duplicate gene names
             # also removes NaNs from the index
             subdf = subdf.groupby(by=subdf.index, dropna=True).sum()
+            subdf.dropna(inplace=True)
             expression = pd.concat([expression, subdf], axis=1)
         expression = pd.DataFrame(expression.mean(1), columns=[column])
         # log transform expression values

--- a/tests/continuous_integration/test_05_network.py
+++ b/tests/continuous_integration/test_05_network.py
@@ -82,5 +82,5 @@ def test_command():
         network(args)
 
         df = pd.read_table(fname, sep="\t")
-        assert df.shape[0] == 30690
+        assert df.shape[0] == 30129
         assert list(df.columns).__eq__(["tf_target", "prob"])


### PR DESCRIPTION
Gene inputs can have NAs and duplicate names (if you converted from ENST to HGNC for example). 
That's bad.

This PR merges duplicate gene names (sums the TPMs, averages the DESeq2 output), 
and drops rows with NAs in important places.

Also skip any chromosomes that don't have any genes on them (either because you have no/few regions, or because the contig has no genes)