### PR TITLE
Influence full_output

### DIFF
--- a/ananse/commands/influence.py
+++ b/ananse/commands/influence.py
@@ -17,9 +17,11 @@ from ananse.utils import check_path
 def influence(args):
     a = ananse.influence.Influence(
         ncore=args.ncore,  # --ncore (optional)
-        Gbf=check_path(args.Gbf),  # --source (Gbf = GRN before)
-        Gaf=check_path(args.Gaf),  # --target (Gaf = GRN after)
+        GRN_source_file=check_path(args.GRN_source_file),  # --source (Gbf = GRN before)
+        GRN_target_file=check_path(args.GRN_target_file),  # --target (Gaf = GRN after)
         outfile=check_path(args.outfile, error_missing=False),  # --output
+        union_grns=args.union_grns,
+        padj_cutoff=args.padj_cutoff,
         degenes=check_path(
             args.expression
         ),  # --degenes (HGNC gene names, padj and log2foldchanges)

--- a/ananse/commands/network.py
+++ b/ananse/commands/network.py
@@ -13,6 +13,7 @@ from ananse.utils import check_path
 from dask.distributed import Client, LocalCluster
 from loguru import logger
 
+
 @logger.catch
 def network(args):
     ncore = args.ncore

--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -55,28 +55,23 @@ def read_network(
 
     # read GRN files
     if full_output == False:
-        rnet = pd.read_csv(
-            fname,
-            sep="\t",
-            usecols=["tf_target", "prob"],
-            dtype="float64",
-            converters={"tf_target": str},
-        )  # read the GRN file)
+        data_columns = ["tf_target", "prob"]
     if full_output:
-        rnet = pd.read_csv(
-            fname,
-            sep="\t",
-            usecols=[
-                "tf_target",
-                "prob",
-                "tf_expression",
-                "target_expression",
-                "weighted_binding",
-                "activity",
-            ],
-            dtype="float64",
-            converters={"tf_target": str},
-        )  # read the GRN file
+        data_columns = [
+            "tf_target",
+            "prob",
+            "tf_expression",
+            "target_expression",
+            "weighted_binding",
+            "activity",
+        ]
+    rnet = pd.read_csv(
+        fname,
+        sep="\t",
+        usecols=data_columns,
+        dtype="float64",
+        converters={"tf_target": str},
+    )  # read the GRN file
     # sort on selection variable
     rnet.sort_values(GRNsort_column, ascending=False, inplace=True)
     if interactions == None:
@@ -436,13 +431,13 @@ class Influence(object):
         """Save the network difference between two cell types to a file."""
         with open(filename, "w") as nw:
             if full_output == False:
-                nw.write(f"TF\ttarget\tweight\n")
+                nw.write("TF\ttarget\tweight\n")
                 for (u, v, d) in self.G.edges(data=True):
                     nw.write(u + "\t" + v + "\t" + str(d["weight"]) + "\n")
             if full_output:
                 logger.info("output full diff network")
                 nw.write(
-                    f"tf\ttarget\tweight\tweight_source\tweight_target\ttf_expr_source\ttf_expr_target\ttg_expr_source\ttg_expr_target\twb_source\twb_target\tsource_tf_act\ttarget_tf_act\n"
+                    "tf\ttarget\tweight\tweight_source\tweight_target\ttf_expr_source\ttf_expr_target\ttg_expr_source\ttg_expr_target\twb_source\twb_target\tsource_tf_act\ttarget_tf_act\n"
                 )
                 for (u, v, d) in self.G.edges(data=True):
                     cols = [

--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -32,42 +32,140 @@ warnings.filterwarnings("ignore")
 # Here because of multiprocessing and pickling
 Expression = namedtuple("Expression", ["score", "absfc", "realfc"])
 
-
-def read_network(fname, edges=100000):
-    """Read network file and return networkx DiGraph."""
-
-    G = nx.DiGraph()
-
-    rnet = pd.read_csv(fname, sep="\t")
-    rnet.sort_values("prob", ascending=False, inplace=True)
+def read_top_interactions(fname, edges = 100000):
+    """Read network file and return the top interactions"""
+    rnet = pd.read_csv(fname, sep="\t")#read the GRN file
+    rnet.sort_values("prob", ascending=False, inplace=True)#sort based on probability score
     rnet = rnet.head(edges)
+    top_int = set(rnet['tf_target'])
+    return(top_int)
+
+
+def read_network(fname, edges=100000, interactions = None ):
+    """Read network file and return networkx DiGraph"""
+    G = nx.DiGraph()#initiate empty network
+    rnet = pd.read_csv(fname, sep="\t")#read the GRN file
+    rnet.sort_values("prob", ascending=False, inplace=True)#sort based on probability score
+    
+    #check method of selecting edges, if a interaction set is provided, export those from the GRN
+    #if not export the edges of the network.
+    if interactions == None:
+        rnet = rnet.head(edges)
+    else:    
+        rnet = rnet[rnet.tf_target.isin(interactions)]
+    
+    edge_atribute_length = len(rnet.columns)#check if network is full output or simple output
     for _, row in rnet.iterrows():
         source, target = row[0].split("_", 1)
-        weight = 0 if len(row) < 2 else float(row[1])
-        try:
-            G.add_edge(source, target, weight=weight, n=1)
-        except Exception:
-            logger.error("Could not parse edge weight.")
-            raise
+        weight = 0 if len(row) < edge_atribute_length else float(row['prob'])
+        #when the GRN with the full output is generated, more data can be exported to the diffnetwork
+        #all the extra data is stored in edge attributes
+        if edge_atribute_length == 6:
+            tf_expression = 0 if len(row) < edge_atribute_length else float(row['tf_expression'])
+            target_expression = 0 if len(row) < edge_atribute_length else float(row['target_expression'])
+            weighted_binding = 0 if len(row) < edge_atribute_length else float(row['weighted_binding'])
+            activity = 0 if len(row) < edge_atribute_length else float(row['activity'])
+            try:
+                G.add_edge(source,
+                        target, 
+                        weight = weight,
+                        weighted_binding = weighted_binding, 
+                        TF_expression = tf_expression,
+                        TF_activity = activity,
+                        TG_expression = target_expression,)
+            except Exception:
+                print("Could not parse edge weight.")
+                raise
+                
+        #if there is only prob score, only that is inc in the GRN
+        else:
+            try:
+                    G.add_edge(source, target, weight=weight, n=1)
+            except Exception:
+                print("Could not parse edge weight.")
+                raise
     return G
 
 
-def difference(S, R):
-    """Calculate the network different between two cell types."""
-    DIF = nx.create_empty_copy(R)
-    for (u, v, d) in S.edges(data=True):
-        if (u, v) not in R.edges:
-            DIF.add_edge(u, v, weight=d["weight"], n=1)
-        else:
-            diff_weight = S.edges[u, v]["weight"] - R.edges[u, v]["weight"]
-            if diff_weight > 0:
-                DIF.add_edge(
-                    u, v, weight=diff_weight, n=1, neglogweight=-np.log(diff_weight)
-                )
+def difference(GRN_source, GRN_target):
+    """Calculate the network different between two GRNs.
+    It first takes the nodes from both networks, and subsequently 
+    First adds the edges from the target network that are missing in
+    the source network.
+    Secondly add the edges present in both but with a higher interaction
+    score in the target network
+    """
+    DIF = nx.create_empty_copy(GRN_source)#copying source GRN nodes
+    nodes_target = nx.create_empty_copy(GRN_target)#copying target GRN nodes
+    DIF.add_nodes_from(list(nodes_target.nodes))#merge the nodes if there are differences 
+    #(which can happen) when taking the header instead of the --unnion-interactions flagg
+
+    #lets check if the full GRN output is loaded and if so output all atributes to the diffnetwork: 
+    full_output_GRN = bool(nx.get_edge_attributes(GRN_source,'TF_expression'))
+    if full_output_GRN:
+        logger.info('calculating diff GRN with full output')
+        #lets load all the differential edges into the diffnetwork
+        for (u, v, a) in GRN_target.edges(data=True):
+            if (u, v) not in GRN_source.edges:
+                #if the edge is not in the target network (when using head instead of union of interactions)
+                #, add all source atributes to the diff network and put the target atributes to 0
+                DIF.add_edge(u, v, weight = a['weight'], 
+                             n = 1,
+                            source_weight = 'NA',
+                            target_weight = GRN_target.edges[u, v]["weight"],
+                            tf_expr_target = a['TF_expression'],
+                            tf_expr_source = 'NA',
+                            tg_expr_target = a['TG_expression'],
+                            tg_expr_source = 'NA',
+                            target_wb = a['weighted_binding'], 
+                            source_wb = 'NA', 
+                            TF_act_target = a['TF_activity'],
+                            TF_act_source = 'NA',
+                            )
+            else: #if the edge is present in both networks and higher in the target than in the source,
+                #calculate the weight difference and output all atributes
+                source_weight = GRN_source.edges[u, v]["weight"]
+                target_weight = GRN_target.edges[u, v]["weight"]
+                wb_source = GRN_source.edges[u, v]["weighted_binding"]
+                wb_target = GRN_target.edges[u, v]["weighted_binding"]
+                
+                diff_weight = target_weight - source_weight
+
+                if diff_weight > 0:#if the interaction probability is higher in the target than in the
+                    #source, add the interaction to the diffnetwork:
+                    DIF.add_edge(
+                        u,
+                        v, 
+                        weight=diff_weight,
+                        source_weight = source_weight,
+                        target_weight = target_weight,
+                        neglogweight=-np.log(diff_weight),
+                        n = 1,
+                        tf_expr_target = a['TF_expression'],
+                        tf_expr_source = GRN_source[u][v]['TF_expression'],
+                        tg_expr_target = a['TG_expression'],
+                        tg_expr_source = GRN_source[u][v]['TG_expression'],
+                        target_wb = a['weighted_binding'], 
+                        source_wb = GRN_source[u][v]['weighted_binding'], 
+                        TF_act_target = a['TF_activity'],
+                        TF_act_source = GRN_source[u][v]['TF_activity'],
+                        )
+    else:
+        logger.info('calculating diff GRN with simple output')
+        #if only the weight is loaded, lets load only that in the diffnetwork:
+        for (u, v, d) in GRN_target.edges(data=True):
+            if (u, v) not in GRN_source.edges:
+                DIF.add_edge(u, v, weight=d["weight"], n=1)
+            else:
+                diff_weight = GRN_target.edges[u, v]["weight"] - GRN_source.edges[u, v]["weight"]
+                if diff_weight > 0:
+                    DIF.add_edge(
+                        u, v, weight=diff_weight, n=1, neglogweight=-np.log(diff_weight)
+                    )
     return DIF
 
 
-def read_expression(fname):
+def read_expression(fname, padj_cutoff = 0.05):
     """
     Read differential gene expression analysis output,
     return dictionary with namedtuples of scores, absolute fold
@@ -81,6 +179,7 @@ def read_expression(fname):
         1. a column with names/IDs (column name is ignored), 
         2. named column "padj" (adjusted p-values)
         3. named column "log2FoldChange"
+    pval = float of the cutoff of which genes will be flagged as differential
 
     Returns
     -------
@@ -102,6 +201,12 @@ def read_expression(fname):
     )[["log2FoldChange", "padj"]]
     # removes NaNs
     df.dropna(inplace=True)
+    #check for duplicated index rows and return an error (but continue running)
+    dup_df = df[df.index.duplicated()]
+    if len(dup_df) > 0:
+        dupped_gene = str(dup_df.index[0])
+        logger.warning(f"duplicated gene names detected in differential expression file e.g.{dupped_gene}")
+        logger.warning(f"taking mean of values of duplicated genes")
     # average values for duplicate gene names (none hopefully)
     df = df.groupby(by=df.index, dropna=True).mean(0)
 
@@ -109,7 +214,7 @@ def read_expression(fname):
     df["fc"] = df["log2FoldChange"].abs()
 
     # get the gscore (absolute fold change if significantly differential)
-    df["score"] = df["fc"] * (df["padj"] < 0.05)
+    df["score"] = df["fc"] * (df["padj"] < padj_cutoff)
 
     for k, row in df.iterrows():
         expression_change[k] = Expression(
@@ -230,7 +335,7 @@ def filter_TF(scores_df, network=None, tpmfile=None, tpm=20, overlap=0.98):
     return scores_df
 
 
-def plot_influscore(infile, outfile):
+def plot_influence(infile, outfile):
     """Plot TF influence score to expression."""
 
     mogrify = pd.read_table(infile, index_col="factor")
@@ -259,40 +364,66 @@ def plot_influscore(infile, outfile):
 
 class Influence(object):
     def __init__(
-        self, outfile, degenes, Gbf=None, Gaf=None, filter=False, edges=100000, ncore=1
+        self, outfile, degenes, GRN_source_file=None, GRN_target_file=None, union_grns=False, filter=False, edges=100000, ncore=1, padj_cutoff = 0.05
     ):
-
         self.ncore = ncore
-        logger.info(f"Reading network(s), using top {edges} edges.")
-        # Load GRNs
-        if Gbf is None and Gaf is not None:
-            self.G = read_network(Gaf, edges=edges)
-            logger.warning("You only provide the target network!")
-        elif Gaf is None and Gbf is not None:
-            self.G = read_network(Gbf, edges=edges)
-            logger.warning("You only provided the source network!")
-        elif Gaf is None and Gbf is None:
-            logger.warning("You should provide at least one ANANSE network file!")
-        else:
-            G1 = read_network(Gbf, edges=edges)
-            G2 = read_network(Gaf, edges=edges)
-            self.G = difference(G2, G1)
-            logger.info(f"Differential network has {len(self.G.edges)} edges.")
-
+        if union_grns == False:
+            logger.info(f"Reading network(s), using top {edges} edges.")
+            # Load GRNs
+            if GRN_source_file is None and GRN_target_file is not None:
+                self.G = read_network(GRN_target_file, edges=edges)
+                logger.warning("You only provide the target network!")
+            elif GRN_target_file is None and GRN_source_file is not None:
+                self.G = read_network(GRN_source_file, edges=edges)
+                logger.warning("You only provided the source network!")
+            elif GRN_target_file is None and GRN_source_file is None:
+                logger.warning("You should provide at least one ANANSE network file!")
+            else:
+                G1_source = read_network(GRN_source_file, edges=edges)
+                G2_target = read_network(GRN_target_file, edges=edges)
+        if union_grns == True:
+            if (GRN_source_file is None) or (GRN_target_file is None):
+                logger.warning("You should provide at least two ANANSE network files to take the interaction union!")
+            else:
+                logger.info(f"Reading network(s), using the union of the top {edges} edges of each GRN.")
+                top_int_source = read_top_interactions(GRN_source_file, edges=edges)
+                top_int_target = read_top_interactions(GRN_target_file, edges=edges)
+                top_int = set.union(top_int_source, top_int_target)
+                G1_source = read_network(GRN_source_file,interactions = top_int)
+                G2_target = read_network(GRN_target_file,interactions = top_int)
+        self.G = difference(G1_source, G2_target)
+        logger.info(f"Differential network has {len(self.G.edges)} edges.")
         # Load expression file
         self.expression_change = read_expression(degenes)
-
         self.outfile = outfile
-
         # Filter TFs
         self.filter = filter
 
     def save_reg_network(self, filename):
         """Save the network difference between two cell types to a file."""
-
+        full_output_GRN = bool(nx.get_edge_attributes(self.G,'tf_expr_source'))
         with open(filename, "w") as nw:
-            for (u, v, d) in self.G.edges(data=True):
-                nw.write(u + "\t" + v + "\t" + str(d["weight"]) + "\n")
+            if full_output_GRN:
+                logger.info('output full diff network')
+                nw.write(f"TF \t target \t weight \t source_weight \t target_weight \t tf_expr_source \t tf_expr_target \t tg_expr_source \t tg_expr_target \t source_wb \t target_wb \t source_Tf_act \t target_Tf_act \n")
+                for (u, v, d) in self.G.edges(data=True):
+                        nw.write(u + "\t" + 
+                                 v + "\t" + 
+                                 str(d["weight"]) + "\t" + 
+                                 str(d["source_weight"]) + "\t" + 
+                                 str(d["target_weight"]) + "\t" + 
+                                 str(d["tf_expr_source"]) + "\t" + 
+                                 str(d["tf_expr_target"]) + "\t" + 
+                                 str(d["tg_expr_source"]) + "\t" + 
+                                 str(d["tg_expr_target"]) + "\t" + 
+                                 str(d["source_wb"]) + "\t" + 
+                                 str(d["target_wb"]) + "\t" + 
+                                 str(d["TF_act_source"]) + "\t" + 
+                                 str(d["TF_act_target"]) + "\n")
+            else:
+                nw.write(f"TF \t target \t weight  \n")
+                for (u, v, d) in self.G.edges(data=True): 
+                    nw.write(u + "\t" + v + "\t" + str(d["weight"]) + "\n")
 
     def run_target_score(self, max_degree=3):
         """Run target score for all TFs."""
@@ -444,6 +575,6 @@ class Influence(object):
 
         if plot is True:
             logger.info("Plotting results.")
-            plot_influscore(
+            plot_influence(
                 self.outfile, ".".join(self.outfile.split(".")[:-1]) + ".pdf"
             )

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -41,7 +41,7 @@ class Network(object):
         gene_bed=None,
         include_promoter=False,
         include_enhancer=True,
-        full_output = False,
+        full_output=False,
     ):
         """
         infer cell type-specific gene regulatory network
@@ -607,17 +607,17 @@ class Network(object):
         alpha=None,
         promoter=2000,
         full_weight_region=5000,
-        full_output = False
+        full_output=False,
     ):
 
         """Create network.
-        
+
         Generates a gene-regulatory network with a TF-target gene interaction "prob" score based on the mean rank of:
         1. Binding score based on ATAC/H3K27ac data of neirby enhancers.
-        2. TF Activity (single score per TF based on general TF motif behaviour in the trained dataset) 
+        2. TF Activity (single score per TF based on general TF motif behaviour in the trained dataset)
         3. TF expression score
         4. Target expression score
-        
+
         Parameters
         ----------
         binding : str
@@ -640,7 +640,7 @@ class Network(object):
             Promoter region, by default 2000.
         full_weight_region : int, optional
             Region that will receive full weight, by default 5000.
-            """
+        """
         # Expression base network
         logger.info("Loading expression")
         df_expression = self.create_expression_network(
@@ -714,13 +714,31 @@ class Network(object):
             out_dir = os.path.abspath(os.path.dirname(outfile))
             os.makedirs(out_dir, exist_ok=True)
             if self.full_output:
-                result[["tf_target", "prob", "tf_expression", "target_expression", "weighted_binding", "activity"]].to_csv(outfile, sep="\t", index=False)
+                result[
+                    [
+                        "tf_target",
+                        "prob",
+                        "tf_expression",
+                        "target_expression",
+                        "weighted_binding",
+                        "activity",
+                    ]
+                ].to_csv(outfile, sep="\t", index=False)
             else:
-                result[["tf_target",  "prob"]].to_csv(outfile, sep="\t", index=False)
+                result[["tf_target", "prob"]].to_csv(outfile, sep="\t", index=False)
 
         else:
             if self.full_output:
-                return result[["tf_target", "prob", "tf_expression", "target_expression", "weighted_binding", "activity"]]
+                return result[
+                    [
+                        "tf_target",
+                        "prob",
+                        "tf_expression",
+                        "target_expression",
+                        "weighted_binding",
+                        "activity",
+                    ]
+                ]
             return result[["tf_target", "prob"]]
 
     def __del__(self):

--- a/ananse/peakpredictor.py
+++ b/ananse/peakpredictor.py
@@ -493,15 +493,15 @@ class PeakPredictor:
         return tmp[self._X_columns]
 
     def _load_model(self, factor, jaccard_cutoff = 0.0):
-    """Load TF-binding model that is:
-    1. trained for that specific TF
-    2. trained on a different TF with a motif overlap of a jacards similarity larger than the cutoff
-    3. a general TF binding model if the other options are not available 
-        Parameters
-        ----------
-        jaccard_cutoff : 
-            minimum jacard similarity score that is needed to use the model of TFA for TFB. 
-        """
+        """Load TF-binding model that is:
+        1. trained for that specific TF
+        2. trained on a different TF with a motif overlap of a jacards similarity larger than the cutoff
+        3. a general TF binding model if the other options are not available 
+            Parameters
+            ----------
+            jaccard_cutoff : 
+                minimum jacard similarity score that is needed to use the model of TFA for TFB. 
+            """
         model = None
         max_edge_weight = 1 - jaccard_cutoff
         if factor in self.factor_models:

--- a/docs/command-line_reference.md
+++ b/docs/command-line_reference.md
@@ -113,6 +113,8 @@ Optional arguments:
                         Number of processes to use for motif scanning
   --pfmscorefile        use precomputed gimmemotifs scores (gimme scan -T -g
                         GENOME INPUTFILE)
+  --jaccard-cutoff      TFs with a motif jaccard similarity of larger than the jaccard-cutoff are linked together for model
+                        selection, default value is 0. Use a higher value e.g. 0.1 to improve robustness of the selected model.
   -h, --help            Show this help message and exit
 ```
 
@@ -154,6 +156,7 @@ Optional arguments:
                         genomepy with the --annotation flag.
   -n NCORE, --ncore NCORE
                         Number of core used.
+  -f , --full-output    Export not only the GRN edge weight, but all values used to calculate the weight to the GRN file
   --include-promoter, --exclude-promoter
                         Include or exclude promoter peaks (<= TSS +/- 2kb) in network inference. By default promoter peaks
                         are included.

--- a/scripts/ananse
+++ b/scripts/ananse
@@ -239,16 +239,6 @@ if __name__ == "__main__":
         action=NegateAction,
         nargs=0,
     )
-#    group.add_argument(
-#        "--simple-output",
-#        "--full-output",
-#        default=False,
-#        help="export only the simple or the full output in the GRN output file. "
-#             "By default only the simple output is exported to the GRN output file",
-#        dest="full_output",
-#        action=NegateAction,
-#        nargs=0,
-#    )
     group.add_argument(
         "-f",
         "--full-output",
@@ -279,7 +269,7 @@ if __name__ == "__main__":
     group.add_argument(
         "-t",
         "--target",
-        dest="Gaf",
+        dest="GRN_target_file",
         help="Network of target cell type.",
         metavar="FILE",
         default=None,
@@ -306,7 +296,7 @@ if __name__ == "__main__":
     group.add_argument(
         "-s",
         "--source",
-        dest="Gbf",
+        dest="GRN_source_file",
         help="Network of source cell type.",
         metavar="FILE",
         default=None,
@@ -326,6 +316,22 @@ if __name__ == "__main__":
         help="Create influence score plot.",
         action="store_true",
         default=False,
+    )
+    group.add_argument(
+        "-u",
+        "--union-grns",
+        dest="union_grns",
+        help="take a set union of the GRN top edges instead of only the top edges",
+        action="store_true",
+        default=False,
+    )
+    group.add_argument(
+        "-j",
+        "--padj",
+        dest="padj_cutoff",
+        help="the pvallue wich clasifies genes (and TFs) as differential in the influence calculations",
+        type=float,
+        default=0.05,
     )
     group.add_argument(
         "-n",


### PR DESCRIPTION
**Changes influence.__init__, influence.read_network & influence.read_top_interactions (influence.py, ananse/influence.py)** 
1. added an optional --union-grn or -u flagg, when added Ananse takes the top edges from both networks, and takes the vallues of these top interactions from each network (instead of adding a 0 if not present in the top head of the other cell type). Downside, it takes a few minuits longer but I think its preferable over the older approach (should it be the default behaviour when suplying multiple networks?). Wrote the new: 'read_top_interactions' function and modified the 'read_network' function to make it work

**#Changes to differential GRN network, influence.difference  (influence.py)**
1. Changed the annotation of Gbf(GRN before) and Gaf  (GRN after), B before A hurts my brain). It now should be  simply GRN_source and GRN_target everywhere. 
2. added automatic support for GRNs generated by --full-output and when the --full-output flagg is used in the network generation all aditional info is also incorporated in the differential GRN diffnetwork file. This drastically helps when needing to look into TF-target genes (my original goal).


Regular diffnetork output:

TF 	 target 	 weight 
ELF3	DMRTA2	0.390689477
ATF6B	MAB21L1	0.380977223
ATF6B	FABP4	0.371913081

New --full-output GRN diffnetork output:

TF 	 target 	 weight 	 source_weight 	 target_weight 	 tf_expr_source 	 tf_expr_target 	 tg_expr_source 	 tg_expr_target 	 source_wb 	 target_wb 	 source_Tf_act 	 target_Tf_act 
ELF3	DMRTA2	0.390689477	0.491605608	0.882295085	0.464918033	0.959839357	0.28405822	0.861821139	0.819622722	0.971442363	0.397823458	0.736077482
ATF6B	MAB21L1	0.380977223	0.505192899	0.886170122	0.826885246	0.961178046	0	0.830369898	0.742858538	0.79429477	0.451027811	0.958837772
ATF6B	FABP4	0.371913081	0.499670645	0.871583726	0.826885246	0.961178046	0	0.84063386	0.720769523	0.725685227	0.451027811	0.958837772

**#Changes read_expression (influence.py, ananse/influence.py)** 
1. Added a warning if duplicated genes are present in the expression file
2. added an optional --padj -j flagg to specify the pval cutoff that ananse uses to call a gene differential (before it was a hardcoded 0.05)
