### PR TITLE
maybe fixes "OSError: Format not recognized"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `ananse network` merges duplicate genes and transcription factors (#142)
 - issue in `ananse influence` when using only 1 network
 - `ananse plot` will no longer warn you incorrectly about your "weight" 
+- `ananse plot` error "OSError: Format: "dot" not recognized."
 
 
 ## [0.3.0] - 2021-07-14

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -17,7 +17,8 @@ dependencies:
   - openpyxl
   - pandas
   - pybedtools
-  - pygraphviz
+  - pydot >=1.4.1   # required for networkx plots
+  - pygraphviz >=1.7   # required for networkx plots
   - pyranges
   - pytables  # required for pandas.read_hfd()
   - scikit-learn


### PR DESCRIPTION
relevant snippets from the traceback
```python
  File ".../ananse/commands/plot.py", line 15, in plot
    plot_TF_GRN(
    └ <function plot_TF_GRN at 0x145cd7df8160>
  File ".../ananse/plot.py", line 187, in plot_TF_GRN
    pos = nx.drawing.nx_agraph.graphviz_layout(TF_G2, prog=network_algorithm)

  File ".../networkx/drawing/nx_agraph.py", line 239, in graphviz_layout
    return pygraphviz_layout(G, prog=prog, root=root, args=args)

  File ".../networkx/drawing/nx_agraph.py", line 287, in pygraphviz_layout
    A.layout(prog=prog, args=args)

  File ".../pygraphviz/agraph.py", line 1466, in layout
    data = self._run_prog(prog, " ".join([args, "-T", output_fmt]))
           │    │         │               │           └ 'dot'
           │    │         │               └ ''
           │    │         └ 'neato'
           │    └ <function AGraph._run_prog at 0x145cc00fc670>
           └ <AGraph <Swig Object of type 'Agraph_t *' at 0x145cd7daaf30>>
  File ".../pygraphviz/agraph.py", line 1387, in _run_prog
    raise OSError(b"".join(errors).decode(self.encoding))
                           │              │    └ 'UTF-8'
                           │              └ <AGraph <Swig Object of type 'Agraph_t *' at 0x145cd7daaf30>>
                           └ [b'Format: "dot" not recognized. No formats found.\nPerhaps "dot -c" needs to be run (with installer\'s privileges) to regist...

OSError: Format: "dot" not recognized. No formats found.
Perhaps "dot -c" needs to be run (with installer's privileges) to register the plugins?
```

`dot -c` output:
```bash
Error: failed to open /usr/lib/x86_64-linux-gnu/graphviz/config6a for write.
```
makes sense on the server... but then the "dot" format should not be registered then. However, we can see it when I run `dot -v`:
```bash
dot - graphviz version 2.40.1 (20161225.0304)
libdir = "/usr/lib/x86_64-linux-gnu/graphviz"
Activated plugin library: libgvplugin_dot_layout.so.6
Using layout: dot:dot_layout
Activated plugin library: libgvplugin_core.so.6
Using render: dot:core
Using device: dot:dot:core
The plugin configuration file:
        /usr/lib/x86_64-linux-gnu/graphviz/config6a
                was successfully loaded.
    render      :  cairo dot dot_json fig gd json json0 map mp pic pov ps svg tk vml vrml xdot xdot_json
    layout      :  circo dot fdp neato nop nop1 nop2 osage patchwork sfdp twopi
    textlayout  :  textlayout
    device      :  bmp canon cmap cmapx cmapx_np dot dot_json eps fig gd gd2 gif gtk gv ico imap imap_np ismap jpe jpeg jpg json json0 mp pdf pic plain plain-ext png pov ps ps2 svg svgz tif tiff tk vml vmlz vrml wbmp x11 xdot xdot1.2 xdot1.4 xdot_json xlib
    loadimage   :  (lib) bmp eps gd gd2 gif ico jpe jpeg jpg png ps svg xbm
```