### PR TITLE
influence edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `ananse influence` made slightly faster.
 - `ananse influence` hopefully uses less memory now.
 - `ananse influence` now skips pvalues for TFs without any targets or non-targets.
+- `ananse influence` will now use the top overlapping edges, instead of the top edges.
 - `ananse plot` will no longer warn you incorrectly about your "weight" 
 - `ananse plot` error "OSError: Format: "dot" not recognized."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `ananse binding` will now only scan the regions overlapping the pfmscorefile and regions (if both are given)
 - changed the hardcoded `.txt` file extensions in `ananse plot` to `.tsv` 
 - `ananse network` now loads the gene bed into pyranges once (instead of once per chromosome).
+- `ananse influence` now used the top 500.000 TF-gene interactions. By default, filtering for highest positive interactions.
 - cleaned up `ananse --help` messages
 
 ### Removed

--- a/ananse/influence.py
+++ b/ananse/influence.py
@@ -29,7 +29,7 @@ def read_top_interactions(
     source, target, edges: Union[int, None] = 100_000, sort_by="prob"
 ):
     """
-    Read two network files and return the top shared interactions,
+    Read two network files and return the top source to target interactions,
     using the designated scoring metric (by default the combined probability).
 
     If edges is none, return all shared interactions.
@@ -62,8 +62,8 @@ def read_top_interactions(
         sys.exit(1)
 
     if edges is not None:
-        # get the top interactions by their combined scores
-        top_int = top_int["source"] * top_int["target"]
+        # get the top differential interactions
+        top_int = top_int["target"] - top_int["source"]
         top_int.sort_values(ascending=False, inplace=True)
         top_int = top_int.head(edges)
 

--- a/scripts/ananse
+++ b/scripts/ananse
@@ -345,18 +345,18 @@ if __name__ == "__main__":
         "-a",
         "--annotation",
         dest="gene_gtf",
-        help="Gene annotation (genomepy name or GTF file) used to quantify expression levels",
+        help="Gene annotation (genomepy name or GTF file) used to quantify expression levels.",
         metavar="GTF",
         default=None,
     )
     group.add_argument(
         "-i",
-        "--edges",
+        "--interactions",
         dest="edges",
-        help="Number of top edges used (default: 100.000).",
+        help="Number of top TF-gene interactions used (default: 500.000).",
         type=int,
         metavar="INT",
-        default=100000,
+        default=500_000,
     )
     group.add_argument(
         "-j",
@@ -369,9 +369,9 @@ if __name__ == "__main__":
     )
     group.add_argument(
         "-c",
-        "--GRNsort-column",
+        "--column",
         dest="GRNsort_column",
-        help="Column of GRN file sorted to select top interactions, 'prob' by default",
+        help="Column of the network file(s) to select top interactions (default: prob).",
         default="prob",
         metavar="STR",
     )

--- a/tests/test_06_influence.py
+++ b/tests/test_06_influence.py
@@ -40,7 +40,9 @@ def test_read_top_interactions():
     fname = "tests/data/influence/network.tsv"
     top = ananse.influence.read_top_interactions(fname, fname, edges=10)
     assert len(top) == 10
-    assert top[0] == "FOXK2—AL935186.11"
+    # I'm cheating here. 2x the same input means no difference.
+    # So the list is sorted lexicographically
+    assert top[0] == "FOXK2—ABCA7"
 
     top = ananse.influence.read_top_interactions(
         fname, fname, edges=1, sort_by="activity"


### PR DESCRIPTION
In this PR:
- **a big `read_top_interactions` change**
- minor linting issues
- default top edges/interactions updated to 500k

Background:
in the master branch, we combine two networks in function `difference()`. This function takes all edges in the source network and all shared edges with a higher probability in the target network ([code](https://github.com/vanheeringen-lab/ANANSE/blob/18995f01657db5e92d4558eff4c1e81d30ff088e/ananse/influence.py#L66)). In the develop branch, we threw out the source-network-only-edges (as ANANSE scores should be compared to each other).

In the develop branch, we also remove spurious edges by filtering for the `top_interactions`:
- Before, `read_top_interactions` was called twice and the top interactions combined. However, `difference()` would then only evaluate the interactions present in both networks.
- With this change, the top interactions are guaranteed to be shared. The selected number of edges will therefore match the analyzed number of edges more closely (they are still filtered for a bigger target weight).
- The _top_ edges are now defined as the edges with the highest _val_ (default: `prob`) difference between source and target, since that is the metric we score on later on as well.