### PR TITLE
fix getting hdf keys

### DIFF
--- a/ananse/peakpredictor.py
+++ b/ananse/peakpredictor.py
@@ -929,11 +929,7 @@ def predict_peaks(
     )
 
     outfile = os.path.join(outdir, "binding.h5")
-    # Make sure we create a new file
-    with open(outfile, "w"):
-        pass
-
-    with HDFStore(outfile, complib="lzo", complevel=9) as hdf:
+    with HDFStore(outfile, "w", complib="lzo", complevel=9) as hdf:
 
         if p.atac_data is not None:
             hdf.put(key="_atac", value=p.atac_data, format="table")
@@ -951,7 +947,7 @@ def predict_peaks(
             try:
                 proba = p.predict_proba(factor, jaccard_cutoff=jaccard_cutoff)
                 hdf.put(
-                    key=f"{factor}",
+                    key=factor,
                     value=proba.iloc[:, -1].reset_index(drop=True).astype(np.float16),
                     format="table",
                 )

--- a/ananse/view.py
+++ b/ananse/view.py
@@ -21,7 +21,8 @@ def get_binding_tfs(binding, all_tfs=False):
         hdf = pd.HDFStore(binding, "r")
         # TODO: This is hacky (depending on "_"), however the hdf.keys() method is
         #       much slower. Currently all TF names do *not* start with "_"
-        tfs = set(x for x in dir(hdf.root) if not x.startswith("_"))
+        keys = hdf.root.__members__
+        tfs = set(k for k in keys if not k.startswith("_"))
         hdf.close()
     return list(tfs)
 


### PR DESCRIPTION
I've been troubleshooting ANANSE all day because I got zero TFs in my binding file. Turns out they are there, `dir(HDFStore.root)` just doesn't show them... For this dataset...?

No idea why this behavior is suddenly flaky, but `HDFStore.root.__members__` does the same, in the same amount of time, and does contain all keys.