### PR TITLE
ignore genes annotated on multiple contigs

### DIFF
--- a/ananse/network.py
+++ b/ananse/network.py
@@ -84,7 +84,7 @@ class Network(object):
         genes.columns = [col.capitalize() for col in genes.columns]
         # Convert to DataFrame & we don't need intron/exon information
         genes = genes.as_df().iloc[:, :6]
-        
+
         # Drop genes found on >1 contig
         genes = genes.drop_duplicates(subset=["Name"], keep=False)
 
@@ -757,7 +757,9 @@ class Network(object):
             bed[col] = 0
         bed.drop_duplicates(inplace=True, ignore_index=True)
         # exclude genes found on >1 contig
-        bed.drop_duplicates(subset=["Name"], keep=False, inplace=True, ignore_index=True)
+        bed.drop_duplicates(
+            subset=["name"], keep=False, inplace=True, ignore_index=True
+        )
         # metrics
         bed_genes = set(bed.name)
         overlap_tf_bed = len(bed_genes & tfs) / len(tfs)

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -84,6 +84,9 @@ class Network(object):
         genes.columns = [col.capitalize() for col in genes.columns]
         # Convert to DataFrame & we don't need intron/exon information
         genes = genes.as_df().iloc[:, :6]
+        
+        # Drop genes found on >1 contig
+        genes = genes.drop_duplicates(subset=["Name"], keep=False)
 
         # Get the TSS only
         genes.loc[genes["Strand"] == "+", "End"] = genes.loc[

--- a/ananse/network.py
+++ b/ananse/network.py
@@ -756,6 +756,8 @@ class Network(object):
         for col in drop_cols:
             bed[col] = 0
         bed.drop_duplicates(inplace=True, ignore_index=True)
+        # exclude genes found on >1 contig
+        bed.drop_duplicates(subset=["Name"], keep=False, inplace=True, ignore_index=True)
         # metrics
         bed_genes = set(bed.name)
         overlap_tf_bed = len(bed_genes & tfs) / len(tfs)


### PR DESCRIPTION
```bash
cat hg38/hg38.gene_names.bed | grep 5S_rRNA

chr1    380607  182944490       5S_rRNA 0       -
chr2    380607  182944490       5S_rRNA 0       -
chr2    380607  182944490       5S_rRNA 0       +
chr6    380607  182944490       5S_rRNA 0       -
chr7    380607  182944490       5S_rRNA 0       -
chr16   380607  182944490       5S_rRNA 0       -
chr17   380607  182944490       5S_rRNA 0       -
chr19   380607  182944490       5S_rRNA 0       -
chrX    380607  182944490       5S_rRNA 0       +
chrUn_KI270442v1        380607  182944490       5S_rRNA 0       +
```

lets just remove these